### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "node": ">=6.0.0"
   },
   "stripes": {
+    "type": "app",
+    "displayName": "Notes",
     "okapiInterfaces": {
       "notes": "1.0"
     },


### PR DESCRIPTION
package.json has a required key, `stripes.type`, which was missing. This isn't really of type "app" but it's a required key so we gotta stick something in there. 